### PR TITLE
Initialize context from middleware and not on get

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,20 @@ function getContext(name, current) {
 }
 
 /**
+ * Initiates the context object on the provided domain
+ * @param domain - A domain object to initialize the context object on
+ * @returns {Object|*}
+ */
+function initContext(domain) {
+	if (!domain) {
+		throw new Error('No domain found when initializing context');
+	}
+
+	domain.__$cntxt__ = Object.create(null);
+	return domain.__$cntxt__;
+}
+
+/**
  * Set the context for a given name
  * @api private
  * @param {String} name - The name of the context
@@ -116,6 +130,7 @@ function contextMiddleware(namespace) {
 		d.add(res);
 		d.on('error', handleError);
 
+		initContext(d);
 		setContext(namespace, Object.create(null), d);
 
 		d.run(next);
@@ -142,12 +157,10 @@ function getCurrent(current) {
 	}
 
 	// no active domain found
-	if (!current) {
+	if (!current || !current.__$cntxt__) {
 		return null;
 	}
 
-	// get/set the internal context store from/on the active domain object
-	current.__$cntxt__ = current.__$cntxt__ || Object.create(null);
 	return current.__$cntxt__;
 }
 

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -196,6 +196,36 @@ describe('request-context', function() {
 
 	});
 
+	describe('init only in middleware', function () {
+		it('get will return undefined several times in a row', function () {
+			assert.deepEqual(reqContext.get('test2'), undefined);
+			assert.deepEqual(reqContext.get('test2'), undefined);
+			assert.deepEqual(reqContext.get('test2'), undefined);
+		});
+
+		it('throws error when not initialized and tries to set', function () {
+			assert.throws(() => reqContext.set('test2:yoyo', 'myVal'), /No active context found to set property/);
+		});
+
+		it('get returns undefined when running in domain context', function () {
+			const d = domain.create();
+
+			d.enter();
+			assert.deepEqual(reqContext.get('test2'), undefined);
+			assert.deepEqual(reqContext.get('test2'), undefined);
+			assert.deepEqual(reqContext.get('test2'), undefined);
+			d.exit();
+		});
+
+		it('throws error when not initialized and tries to set when running in domain context', function () {
+			const d = domain.create();
+
+			d.enter();
+			assert.throws(() => reqContext.set('test2:yoyo', 'myVal'), /No active context found to set property/);
+			d.exit();
+		});
+	});
+
 	describe('context path syntax', function () {
 
 		it('should set and get a property for a path', function (done) {
@@ -207,6 +237,9 @@ describe('request-context', function() {
 			}
 
 			function run() {
+				// Init context like we do in the middleware
+				domain.active.__$cntxt__ = {};
+
 				setTimeout(setAsync, 0);
 				reqContext.setContext('test:value', testValue);
 				setTimeout(check, 0);


### PR DESCRIPTION
When running the entire express app inside a domain context, the ```domain.active``` has value.
If we call ```get```/```getContext``` for the first time, it will initialize the ```___$cntxt___``` object before we created our request context domain.
In this situation the middleware will not create another domain, and the outer domain will be used for all requests.
The problematic flow is this:
```
// Running inside a domain context (aka domain X)

// Somewhere we do...
contextService.get('request');

// express's middleware declaration
app.use(contextService.middleware('request')) // Another domain hasn't been created

// inside an express route
contextService.set('request:userId', '123'); // value saved on domain X
```

The fix will initialize the context object only within the middleware, ```get``` and ```set``` calls will address the request-context domain only